### PR TITLE
feat: option to remove scope from folder names

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,11 @@
           "type": "array",
           "default": [],
           "description": "An array of custom 'regex/prefix' pairs like: [{regex:'foo', prefix:'bar'}, {regex:'fffoo', prefix:'bbbar'}]"
+        },
+        "monorepoWorkspace.folders.removeScope": {
+          "type": "boolean",
+          "default": false,
+          "description": "Remove scope from folder names i.e. @scope/my-package -> my-package"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "monorepoWorkspace.includeRoot": {
           "type": "boolean",
           "default": true,
-          "description": "Inlcude the top-level monorepo root path as a workspace folder"
+          "description": "Include the top-level monorepo root path as a workspace folder"
         },
         "monorepoWorkspace.folders.regex.apps": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ function getFolderEmoji(root: string, pkgRoot: string) {
 async function getPackageFolders(
   includeRoot = true
 ): Promise<WorkspaceFolderItem[] | undefined> {
+  const config = vscodeWorkspace.getConfiguration("monorepoWorkspace.folders")
   const cwd = vscodeWorkspace.workspaceFolders?.[0].uri.fsPath
   if (cwd) {
     const workspace = await getWorkspace({
@@ -65,8 +66,11 @@ async function getPackageFolders(
           .getPackages()
           .filter((p) => p.root !== workspace.root)
           .map((p) => {
+            const name = config.get<boolean>("removeScope")
+              ? p.name.replace(/^@.+\//u, "")
+              : p.name
             return {
-              label: `${getFolderEmoji(workspace.root, p.root)}${p.name}`,
+              label: `${getFolderEmoji(workspace.root, p.root)}${name}`,
               description: `at ${path.relative(workspace.root, p.root)}`,
               root: Uri.file(p.root),
               isRoot: false,


### PR DESCRIPTION
## Summary

Adds an option to remove the scope from workspace folder names. Closes #85.

## Issue

Currently, all folder names include the package scope i.e. these are displayed as:

```
@scope/app1
@scope/app2
```

In many monorepos, the scope is the organisation name, so having this present all the time just extra visual distraction, without imparting any additional information.

## PR

This PR introduces a new setting `removeScope`. When `removeScope` is set to `true`, all package names will have the scope removed:

```diff
- @scope/app1
+ app1
- @scope/app2
+ app2
```

_(Also fixes a small typo in `package.json`)_

## Breaking changes

This PR is non-breaking. The `removeScope` setting defaults to `false`, so existing users will not see any difference unless they change the setting.