### PR TITLE
feat: make the list of the selected folders sorted by picked or not

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,8 +128,9 @@ async function select(items?: WorkspaceFolderItem[]) {
   if (!items) items = await getPackageFolders()
   if (!items) return
   const itemsSet = new Map(items.map((item) => [item.root.fsPath, item]))
-  const folders = vscodeWorkspace.workspaceFolders
-
+  // Sort the items so that the selected folders are on top
+  items.sort((a, b) => Number(a.picked || 0) - Number(b.picked || 0))
+  
   if (folders) {
     for (const folder of folders) {
       if (itemsSet.has(folder.uri.fsPath)) {


### PR DESCRIPTION
As a user working in a monorepo with a large number of folders, 
it can be difficult to locate and close all open folders when switching to a new feature that requires a different set of microservices. 

To address this issue, I have implemented a feature that sorts the open folders to the top of the select interface, making it easier to locate and close them as needed. 

This should improve the user experience and make it more efficient to switch between different features and sets of microservices.